### PR TITLE
Added support for mentioning files and directories

### DIFF
--- a/lua/tau/agents.lua
+++ b/lua/tau/agents.lua
@@ -186,8 +186,6 @@ function M.build_system_prompt(cwd, provider_name)
 		table.insert(parts, ctx.agents)
 	end
 
-
-
 	if ctx.append then
 		table.insert(parts, ctx.append)
 	end
@@ -213,6 +211,8 @@ Available tools:
 - edit_buffer: Edit an open buffer with exact text replacement (via Neovim API)
 - goto_buffer: Switch the user's view to a specific buffer
 - open_file_to_buffer: Open a file path in the main editor window, not Tau panels (optional line jump and split)
+
+The user may include file or directory references in messages as [file: …] or [directory: …] (from @ completion or :TauPromptContext).
 
 Prefer grep/find/ls over bash for file discovery. Use edit for precise changes, write for new files or complete rewrites. When editing buffers, prefer edit_buffer over write to preserve unsaved changes.
 ]]

--- a/lua/tau/auth.lua
+++ b/lua/tau/auth.lua
@@ -3,120 +3,123 @@ local M = {}
 local auth_path = vim.fn.stdpath("data") .. "/tau/auth.json"
 
 local function ensure_dir()
-  local dir = vim.fn.fnamemodify(auth_path, ":h")
-  if vim.fn.isdirectory(dir) == 0 then
-    local ok = vim.fn.mkdir(dir, "p", 448)
-    if ok ~= 1 then
-      vim.notify("Failed to create auth directory: " .. dir, vim.log.levels.ERROR)
-      return false
-    end
-  end
-  return true
+	local dir = vim.fn.fnamemodify(auth_path, ":h")
+	if vim.fn.isdirectory(dir) == 0 then
+		local ok = vim.fn.mkdir(dir, "p", 448)
+		if ok ~= 1 then
+			vim.notify("Failed to create auth directory: " .. dir, vim.log.levels.ERROR)
+			return false
+		end
+	end
+	return true
 end
 
 local function load()
-  if vim.fn.filereadable(auth_path) == 0 then
-    return {}
-  end
-  local f = io.open(auth_path, "r")
-  if not f then
-    return {}
-  end
-  local content = f:read("*all")
-  f:close()
-  local success, data = pcall(vim.json.decode, content)
-  if not success then
-    vim.notify("Failed to parse auth file: " .. data, vim.log.levels.WARN)
-    return {}
-  end
-  return data or {}
+	if vim.fn.filereadable(auth_path) == 0 then
+		return {}
+	end
+	local f = io.open(auth_path, "r")
+	if not f then
+		return {}
+	end
+	local content = f:read("*all")
+	f:close()
+	local success, data = pcall(vim.json.decode, content)
+	if not success then
+		vim.notify("Failed to parse auth file: " .. data, vim.log.levels.WARN)
+		return {}
+	end
+	return data or {}
 end
 
 local function save(data)
-  if not ensure_dir() then
-    return false
-  end
-  local content = vim.json.encode(data)
-  local f, err = io.open(auth_path, "w")
-  if not f then
-    vim.notify("Failed to write auth file: " .. auth_path .. " (" .. (err or "unknown error") .. ")", vim.log.levels.ERROR)
-    return false
-  end
-  f:write(content)
-  f:close()
+	if not ensure_dir() then
+		return false
+	end
+	local content = vim.json.encode(data)
+	local f, err = io.open(auth_path, "w")
+	if not f then
+		vim.notify(
+			"Failed to write auth file: " .. auth_path .. " (" .. (err or "unknown error") .. ")",
+			vim.log.levels.ERROR
+		)
+		return false
+	end
+	f:write(content)
+	f:close()
 
-  vim.uv.fs_chmod(auth_path, 384)
-  return true
+	vim.uv.fs_chmod(auth_path, 384)
+	return true
 end
 
 local function resolve_key(value)
-  if not value or value == "" then
-    return nil
-  end
+	if not value or value == "" then
+		return nil
+	end
 
-  if value:sub(1, 1) == "!" then
-    local cmd = value:sub(2)
-    local result = vim.fn.system(cmd)
-    if vim.v.shell_error ~= 0 then
-      return nil
-    end
-    return vim.trim(result)
-  end
+	if value:sub(1, 1) == "!" then
+		local cmd = value:sub(2)
+		local result = vim.fn.system(cmd)
+		if vim.v.shell_error ~= 0 then
+			return nil
+		end
+		return vim.trim(result)
+	end
 
-  if value:match("^[A-Z][A-Z0-9_]+$") and not value:match("sk%-") then
-    local env_val = vim.env[value]
-    if env_val then
-      return env_val
-    end
-  end
+	if value:match("^[A-Z][A-Z0-9_]+$") and not value:match("sk%-") then
+		local env_val = vim.env[value]
+		if env_val then
+			return env_val
+		end
+	end
 
-  return value
+	return value
 end
 
 function M.get_key(provider_name)
-  local data = load()
-  local entry = data[provider_name]
-  if entry then
-    if type(entry) == "table" and entry.type == "api_key" then
-      return resolve_key(entry.key)
-    elseif type(entry) == "string" then
-      return resolve_key(entry)
-    end
-  end
-  return nil
+	local data = load()
+	local entry = data[provider_name]
+	if entry then
+		if type(entry) == "table" and entry.type == "api_key" then
+			return resolve_key(entry.key)
+		elseif type(entry) == "string" then
+			return resolve_key(entry)
+		end
+	end
+	return nil
 end
 
 function M.set_key(provider_name, key)
-  local data = load()
-  data[provider_name] = { type = "api_key", key = key }
-  return save(data)
+	local data = load()
+	data[provider_name] = { type = "api_key", key = key }
+	return save(data)
 end
 
 function M.remove_key(provider_name)
-  local data = load()
-  if data[provider_name] then
-    data[provider_name] = nil
-    return save(data)
-  end
-  return false
+	local data = load()
+	if data[provider_name] then
+		data[provider_name] = nil
+		return save(data)
+	end
+	return false
 end
 
 function M.list_providers()
-  local data = load()
-  local providers = {}
-  for k in pairs(data) do
-    table.insert(providers, k)
-  end
-  table.sort(providers)
-  return providers
+	local data = load()
+	local providers = {}
+	for k in pairs(data) do
+		table.insert(providers, k)
+	end
+	table.sort(providers)
+	return providers
 end
 
 function M.has_key(provider_name)
-  return M.get_key(provider_name) ~= nil
+	return M.get_key(provider_name) ~= nil
 end
 
 function M.get_auth_path()
-  return auth_path
+	return auth_path
 end
 
 return M

--- a/lua/tau/config.lua
+++ b/lua/tau/config.lua
@@ -9,6 +9,9 @@ local defaults = {
 
 	models = nil,
 
+	mention_provider = "files",
+	mention_plugins = {},
+
 	layout = {
 		default = "side",
 		side = {

--- a/lua/tau/health.lua
+++ b/lua/tau/health.lua
@@ -58,6 +58,33 @@ local function check_provider_config()
   end
 end
 
+local function check_mentions()
+  local ok, mentions = pcall(require, "tau.mentions")
+  if not ok then
+    vim.health.warn("tau.mentions could not be loaded")
+    return
+  end
+  mentions.ensure_default()
+  local _, name = mentions.get_active()
+  vim.health.ok(string.format("Mention provider: %s", name or "?"))
+  local names = mentions.list_names()
+  if #names > 1 then
+    vim.health.info("Registered: " .. table.concat(names, ", "))
+  end
+end
+
+local function check_blink()
+  if not pcall(require, "blink.cmp.config") then
+    return
+  end
+  local providers = require("blink.cmp.config").sources.providers
+  if providers.tau_mentions then
+    vim.health.ok("blink.cmp tau_mentions provider is registered")
+  else
+    vim.health.info("blink.cmp without tau_mentions; open Tau once or add the provider manually")
+  end
+end
+
 M.run = function(silent)
   if not vim.health then
     if not silent then
@@ -69,6 +96,8 @@ M.run = function(silent)
   check_nvim_version()
   check_curl()
   check_provider_config()
+  check_mentions()
+  check_blink()
 end
 
 return M

--- a/lua/tau/init.lua
+++ b/lua/tau/init.lua
@@ -6,6 +6,9 @@ function M.setup(opts)
 	opts = opts or {}
 	config.setup(opts)
 	require("tau.plugin").init({ plugins = opts.plugins })
+	require("tau.mentions").init({
+		mention_plugins = opts.mention_plugins or {},
+	})
 end
 
 function M.show(opts)
@@ -265,22 +268,16 @@ function M.list_logins()
 	vim.notify("Stored providers: " .. table.concat(providers, ", "), vim.log.levels.INFO)
 end
 
+function M.insert_prompt_context(opts)
+	return require("tau.mentions").insert_into_prompt(opts or {})
+end
+
 function M.send_mention()
-	local mention = require("tau.ui.complete").send_mention_for_buffer()
-	if mention then
-		local ui = require("tau.ui")
-		if not ui.active then
-			M.show()
-		end
-		ui.focus_prompt()
-		local lines = vim.api.nvim_buf_get_lines(ui.active.prompt_buf, 0, -1, false)
-		if #lines > 0 and lines[#lines] ~= "" then
-			table.insert(lines, mention)
-		else
-			lines[#lines] = mention
-		end
-		vim.api.nvim_buf_set_lines(ui.active.prompt_buf, 0, -1, false, lines)
-	end
+	return M.insert_prompt_context({})
+end
+
+function M.register_mention_provider(provider)
+	require("tau.mentions").register(provider)
 end
 
 function M.attach_image(path)
@@ -334,6 +331,10 @@ end
 
 function M.register_provider(plugin_module)
 	require("tau.plugin").register_provider(plugin_module)
+end
+
+function M.get_mention_provider()
+	return require("tau.mentions").get_active()
 end
 
 return M

--- a/lua/tau/integrations/blink.lua
+++ b/lua/tau/integrations/blink.lua
@@ -1,0 +1,25 @@
+local ok, complete_func = pcall(require, "blink.cmp.sources.complete_func")
+if not ok then
+	return {
+		new = function()
+			error("tau.integrations.blink requires blink.cmp")
+		end,
+	}
+end
+
+local M = {}
+
+function M.new(opts, config)
+	config = vim.tbl_deep_extend("force", {}, config or {})
+	config.opts = vim.tbl_deep_extend("force", {
+		complete_func = function()
+			if vim.bo.filetype ~= "tau-prompt" then
+				return nil
+			end
+			return "v:lua.__tau_completefunc"
+		end,
+	}, config.opts or {}, opts or {})
+	return complete_func.new(nil, config)
+end
+
+return M

--- a/lua/tau/mentions/init.lua
+++ b/lua/tau/mentions/init.lua
@@ -1,0 +1,168 @@
+local M = {}
+
+local providers = {}
+local default_name = "files"
+
+function M.ensure_default()
+	if not providers[default_name] then
+		M.register(require("tau.mentions.providers.files").create())
+	end
+end
+
+function M.register(provider)
+	if not provider or not provider.name then
+		error("mention provider must have a name")
+	end
+	providers[provider.name] = provider
+end
+
+function M.get(name)
+	M.ensure_default()
+	return providers[name]
+end
+
+function M.list_names()
+	M.ensure_default()
+	local n = {}
+	for k in pairs(providers) do
+		table.insert(n, k)
+	end
+	table.sort(n)
+	return n
+end
+
+function M.get_active()
+	M.ensure_default()
+	local cfg = require("tau.config").get()
+	local name = cfg.mention_provider or default_name
+	local p = providers[name]
+	if not p then
+		vim.notify(
+			"tau: unknown mention_provider '" .. tostring(name) .. "', using " .. default_name,
+			vim.log.levels.WARN
+		)
+		return providers[default_name], default_name
+	end
+	return p, name
+end
+
+function M.build_ctx()
+	local session = require("tau.state").get_session()
+	return {
+		cwd = vim.fn.getcwd(),
+		session_cwd = session and session.cwd or nil,
+	}
+end
+
+function M.completefunc(findstart, base)
+	M.ensure_default()
+	local line = vim.api.nvim_get_current_line()
+	local col = vim.api.nvim_win_get_cursor(0)[2]
+	local trigger = ""
+
+	if findstart == 1 then
+		local col1 = col + 1
+		for i = col1, 1, -1 do
+			local ch = line:sub(i, i)
+			if ch == "@" then
+				return i - 1
+			end
+			if ch == " " or ch == "\t" then
+				return -2
+			end
+		end
+		return -2
+	end
+
+	for i = math.min(col + 1, #line), 1, -1 do
+		local ch = line:sub(i, i)
+		if ch == "@" then
+			trigger = "@"
+			break
+		end
+	end
+
+	local ctx = M.build_ctx()
+	local p = M.get_active()
+	local files = providers.files
+
+	if trigger == "@" then
+		local at = p.complete_at or (files and files.complete_at)
+		if at then
+			return at(findstart, base, ctx)
+		end
+	end
+
+	return {}
+end
+
+function M.expand(text)
+	local p = select(1, M.get_active())
+	local files = providers.files
+	local fn = p.expand or (files and files.expand)
+	if not fn then
+		return text
+	end
+	return fn(text, M.build_ctx())
+end
+
+function M.validate(text)
+	local p = select(1, M.get_active())
+	local files = providers.files
+	local fn = p.validate or (files and files.validate)
+	if not fn then
+		return {}
+	end
+	return fn(text, M.build_ctx())
+end
+
+function M.insert_from_editor(opts)
+	local p = select(1, M.get_active())
+	local files = providers.files
+	local fn = p.insert_from_editor or (files and files.insert_from_editor)
+	if not fn then
+		return nil
+	end
+	return fn(opts or {}, M.build_ctx())
+end
+
+function M.insert_into_prompt(opts)
+	local text = M.insert_from_editor(opts)
+	if not text then
+		return false
+	end
+	local ui = require("tau.ui")
+	if not ui.active then
+		ui.open()
+	end
+	ui.focus_prompt()
+	local buf = ui.active.prompt_buf
+	local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+	if #lines == 0 then
+		lines = { text }
+	else
+		local last = lines[#lines] or ""
+		if vim.trim(last) ~= "" then
+			lines[#lines] = last .. " " .. text
+		else
+			lines[#lines] = text
+		end
+	end
+	vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+	return true
+end
+
+function M.init(opts)
+	opts = opts or {}
+	M.register(require("tau.mentions.providers.files").create())
+	for _, mod in ipairs(opts.mention_plugins or {}) do
+		local ok, err = pcall(function()
+			require(mod)
+		end)
+		if not ok then
+			vim.notify("tau mentions: failed to load " .. tostring(mod) .. ": " .. tostring(err), vim.log.levels.WARN)
+		end
+	end
+end
+
+return M

--- a/lua/tau/mentions/providers/files.lua
+++ b/lua/tau/mentions/providers/files.lua
@@ -1,0 +1,231 @@
+local M = {}
+
+local MAX_PATH_COMPLETIONS = 500
+
+local function normalize_base(base)
+	base = base or ""
+	base = vim.trim(base)
+	base = base:gsub("^%./", "")
+	base = base:gsub("^@", "")
+	return base
+end
+
+local function rel_matches(rel, base)
+	if base == "" then
+		return true
+	end
+	if #base <= #rel and rel:sub(1, #base) == base then
+		return true
+	end
+	if rel:find("/" .. base, 1, true) then
+		return true
+	end
+	local tail = vim.fn.fnamemodify(rel, ":t")
+	return #base <= #tail and tail:sub(1, #base) == base
+end
+
+local function gather_path_matches(base)
+	local cwd = vim.fn.getcwd()
+	base = normalize_base(base)
+	local rel_dir = "."
+	if base:find("/") then
+		rel_dir = vim.fn.fnamemodify(base, ":h")
+		if rel_dir == "." or rel_dir == "" then
+			rel_dir = "."
+		end
+	end
+	local globpat = (rel_dir == ".") and "**/*" or (rel_dir .. "/**/*")
+	local paths = vim.fn.globpath(cwd, globpat, false, true)
+	if type(paths) ~= "table" then
+		paths = {}
+	end
+
+	local files = {}
+	local dirs = {}
+	for _, f in ipairs(paths) do
+		if vim.fn.isdirectory(f) == 1 then
+			local rel = vim.fn.fnamemodify(f, ":.")
+			if rel ~= "." and rel ~= ".." and rel_matches(rel, base) then
+				table.insert(dirs, rel .. "/")
+			end
+		elseif vim.fn.filereadable(f) == 1 then
+			local rel = vim.fn.fnamemodify(f, ":.")
+			if rel_matches(rel, base) then
+				table.insert(files, rel)
+			end
+		end
+	end
+
+	table.sort(files)
+	table.sort(dirs)
+	local out_files = {}
+	local out_dirs = {}
+	for _, r in ipairs(files) do
+		if #out_files + #out_dirs >= MAX_PATH_COMPLETIONS then
+			break
+		end
+		table.insert(out_files, r)
+	end
+	for _, r in ipairs(dirs) do
+		if #out_files + #out_dirs >= MAX_PATH_COMPLETIONS then
+			break
+		end
+		table.insert(out_dirs, r)
+	end
+	return out_files, out_dirs
+end
+
+local function resolve_cwd(path, ctx)
+	local cwd = (ctx and ctx.cwd) or vim.fn.getcwd()
+	if vim.fn.has("win32") == 1 and path:match("^%a:/") then
+		return path
+	end
+	if path:sub(1, 1) == "/" or path:sub(1, 1) == "~" then
+		return vim.fn.fnamemodify(path, ":p")
+	end
+	return cwd .. "/" .. path
+end
+
+local function path_for_bracket(rel)
+	if vim.fn.has("win32") == 1 and rel:match("^%a:/") then
+		return rel
+	end
+	if rel:sub(1, 1) == "/" or rel:sub(1, 2) == "./" or rel:sub(1, 3) == "../" then
+		return rel
+	end
+	return "./" .. rel
+end
+
+function M.expand(text, ctx)
+	local cwd = (ctx and ctx.cwd) or vim.fn.getcwd()
+	local result = text
+
+	result = result:gsub("@([%w%_%-%./]+)/ ", function(path)
+		return "[directory: " .. path .. "/] "
+	end)
+
+	result = result:gsub("@([%w%_%-%./]+)", function(path)
+		local full_path = resolve_cwd(path, ctx)
+		if vim.fn.filereadable(full_path) == 1 then
+			local bufnr = vim.fn.bufnr(full_path)
+			if bufnr ~= -1 then
+				local line = vim.api.nvim_win_get_cursor(0)[1]
+				return string.format("[file: %s, line: %d]", path, line)
+			end
+			return "[file: " .. path .. "]"
+		elseif vim.fn.isdirectory(full_path) == 1 then
+			return "[directory: " .. path .. "]"
+		end
+		return "@" .. path
+	end)
+
+	return result
+end
+
+function M.validate(text, ctx)
+	local cwd = (ctx and ctx.cwd) or vim.fn.getcwd()
+	local invalid = {}
+	for mention in text:gmatch("%[file: ([^%]]+)%]") do
+		local path = mention:gsub(", line: %d+", ""):gsub(", lines: %d+%-%d+", "")
+		local full = resolve_cwd(path, { cwd = cwd })
+		if vim.fn.filereadable(full) ~= 1 and vim.fn.isdirectory(full) ~= 1 then
+			table.insert(invalid, path)
+		end
+	end
+	for mention in text:gmatch("%[directory: ([^%]]+)%]") do
+		local path = vim.trim(mention):gsub("/$", "")
+		local full = resolve_cwd(path, { cwd = cwd })
+		if vim.fn.isdirectory(full) ~= 1 then
+			table.insert(invalid, path)
+		end
+	end
+	return invalid
+end
+
+function M.insert_from_editor(opts, ctx)
+	opts = opts or {}
+	local buf = opts.bufnr or vim.api.nvim_get_current_buf()
+	local name = vim.api.nvim_buf_get_name(buf)
+	if name == "" then
+		vim.notify("No file for buffer", vim.log.levels.WARN)
+		return nil
+	end
+
+	local rel = vim.fn.fnamemodify(name, ":.")
+	local line1 = opts.line1
+	local line2 = opts.line2
+
+	if line1 == nil or line2 == nil then
+		local mode = vim.fn.mode(1)
+		local vis = mode:sub(1, 1)
+		if vis == "v" or vis == "V" or vis == "\022" then
+			line1 = vim.fn.line("v")
+			line2 = vim.fn.line(".")
+			if line1 > line2 then
+				line1, line2 = line2, line1
+			end
+		else
+			line1 = vim.fn.line(".")
+			line2 = line1
+		end
+	end
+
+	if line1 == line2 then
+		return "[file: " .. rel .. ", line: " .. line1 .. "]"
+	end
+	return "[file: " .. rel .. ", lines: " .. line1 .. "-" .. line2 .. "]"
+end
+
+function M.complete_at(findstart, base, ctx)
+	if findstart == 1 then
+		local line = vim.api.nvim_get_current_line()
+		local col0 = vim.api.nvim_win_get_cursor(0)[2]
+		local col1 = col0 + 1
+
+		for i = col1, 1, -1 do
+			local ch = line:sub(i, i)
+			if ch == "@" then
+				return i - 1
+			end
+			if ch == " " or ch == "\t" then
+				return -2
+			end
+		end
+		return -2
+	end
+
+	local results = {}
+	local files, dirs = gather_path_matches(base)
+	for _, f in ipairs(files) do
+		local p = path_for_bracket(f)
+		table.insert(results, {
+			word = "[file: " .. p .. "]",
+			abbr = f,
+			menu = "[file]",
+		})
+	end
+	for _, d in ipairs(dirs) do
+		local dpath = d:gsub("/$", "")
+		local p = path_for_bracket(dpath)
+		table.insert(results, {
+			word = "[directory: " .. p .. "]",
+			abbr = d,
+			menu = "[dir]",
+		})
+	end
+
+	return results
+end
+
+function M.create()
+	return {
+		name = "files",
+		priority = 0,
+		expand = M.expand,
+		validate = M.validate,
+		insert_from_editor = M.insert_from_editor,
+		complete_at = M.complete_at,
+	}
+end
+
+return M

--- a/lua/tau/state.lua
+++ b/lua/tau/state.lua
@@ -5,69 +5,69 @@ M.current_tab = nil
 M.active_tab_id = nil
 
 function M.init()
-  M.sessions = {}
-  M.current_tab = vim.api.nvim_get_current_tabpage()
+	M.sessions = {}
+	M.current_tab = vim.api.nvim_get_current_tabpage()
 end
 
 function M.get_session(tab_id)
-  tab_id = tab_id or vim.api.nvim_get_current_tabpage()
-  return M.sessions[tab_id]
+	tab_id = tab_id or vim.api.nvim_get_current_tabpage()
+	return M.sessions[tab_id]
 end
 
 function M.set_session(tab_id, session)
-  tab_id = tab_id or vim.api.nvim_get_current_tabpage()
-  M.sessions[tab_id] = session
+	tab_id = tab_id or vim.api.nvim_get_current_tabpage()
+	M.sessions[tab_id] = session
 end
 
 function M.clear_session(tab_id)
-  tab_id = tab_id or vim.api.nvim_get_current_tabpage()
-  M.sessions[tab_id] = nil
+	tab_id = tab_id or vim.api.nvim_get_current_tabpage()
+	M.sessions[tab_id] = nil
 end
 
 function M.create_session(opts)
-  opts = opts or {}
-  return {
-    id = opts.id or vim.fn.strftime("%Y%m%d-%H%M%S") .. "-" .. vim.fn.rand(),
-    cwd = opts.cwd or vim.fn.getcwd(),
-    name = opts.name or nil,
-    messages = opts.messages or {},
-    model = opts.model or require("tau.config").get().provider.model,
-    provider = opts.provider or require("tau.config").get().provider.name,
-    tokens_used = 0,
-    context_limit = 0,
-    compacted_count = 0,
-    created_at = vim.fn.localtime(),
-    updated_at = vim.fn.localtime(),
-  }
+	opts = opts or {}
+	return {
+		id = opts.id or vim.fn.strftime("%Y%m%d-%H%M%S") .. "-" .. vim.fn.rand(),
+		cwd = opts.cwd or vim.fn.getcwd(),
+		name = opts.name or nil,
+		messages = opts.messages or {},
+		model = opts.model or require("tau.config").get().provider.model,
+		provider = opts.provider or require("tau.config").get().provider.name,
+		tokens_used = 0,
+		context_limit = 0,
+		compacted_count = 0,
+		created_at = vim.fn.localtime(),
+		updated_at = vim.fn.localtime(),
+	}
 end
 
 function M.update_session_tokens(tab_id)
-  local session = M.get_session(tab_id)
-  if not session then
-    return
-  end
+	local session = M.get_session(tab_id)
+	if not session then
+		return
+	end
 
-  local context = require("tau.context")
-  local model = session.model or require("tau.config").get().provider.model
-  session.tokens_used = context.count_messages_tokens(session.messages)
-  session.context_limit = context.get_context_limit(model)
-  session.updated_at = vim.fn.localtime()
+	local context = require("tau.context")
+	local model = session.model or require("tau.config").get().provider.model
+	session.tokens_used = context.count_messages_tokens(session.messages)
+	session.context_limit = context.get_context_limit(model)
+	session.updated_at = vim.fn.localtime()
 end
 
 function M.get_token_info(tab_id)
-  local session = M.get_session(tab_id)
-  if not session then
-    return nil
-  end
+	local session = M.get_session(tab_id)
+	if not session then
+		return nil
+	end
 
-  M.update_session_tokens(tab_id)
+	M.update_session_tokens(tab_id)
 
-  return {
-    used = session.tokens_used,
-    limit = session.context_limit,
-    ratio = session.context_limit > 0 and session.tokens_used / session.context_limit or 0,
-    compacted = session.compacted_count,
-  }
+	return {
+		used = session.tokens_used,
+		limit = session.context_limit,
+		ratio = session.context_limit > 0 and session.tokens_used / session.context_limit or 0,
+		compacted = session.compacted_count,
+	}
 end
 
 return M

--- a/lua/tau/ui/complete.lua
+++ b/lua/tau/ui/complete.lua
@@ -1,171 +1,20 @@
 local M = {}
-
-local function find_files(base)
-  local cwd = vim.fn.getcwd()
-  local pattern = base ~= "" and (base .. "*") or "*"
-  local files = vim.fn.globpath(cwd, pattern, false, true)
-
-  local results = {}
-  for _, f in ipairs(files) do
-    local rel = vim.fn.fnamemodify(f, ":.")
-    if vim.fn.isdirectory(f) == 1 then
-      table.insert(results, rel .. "/")
-    else
-      table.insert(results, rel)
-    end
-  end
-
-  table.sort(results)
-  return results
-end
-
-local function find_dirs(base)
-  local cwd = vim.fn.getcwd()
-  local pattern = base ~= "" and (base .. "*") or "*"
-  local files = vim.fn.globpath(cwd, pattern, false, true)
-
-  local results = {}
-  for _, f in ipairs(files) do
-    if vim.fn.isdirectory(f) == 1 then
-      table.insert(results, vim.fn.fnamemodify(f, ":.") .. "/")
-    end
-  end
-
-  table.sort(results)
-  return results
-end
-
-local COMMANDS = {
-  { word = "/model", info = "Switch model" },
-  { word = "/settings", info = "Open settings" },
-  { word = "/compact", info = "Compact context" },
-  { word = "/tree", info = "Session tree" },
-  { word = "/fork", info = "Fork session" },
-  { word = "/clone", info = "Clone session" },
-  { word = "/new", info = "New session" },
-  { word = "/stop", info = "Stop agent" },
-  { word = "/abort", info = "Abort turn" },
-  { word = "/agents", info = "Show agent files" },
-  { word = "/thinking", info = "Toggle thinking" },
-}
+local mentions = require("tau.mentions")
 
 function M.completefunc(findstart, base)
-  if findstart == 1 then
-    local line = vim.api.nvim_get_current_line()
-    local col = vim.api.nvim_win_get_cursor(0)[2]
-
-    for i = col, 1, -1 do
-      local ch = line:sub(i, i)
-      if ch == "@" or ch == "/" then
-        return i - 1
-      end
-      if ch == " " or ch == "\t" then
-        return -2
-      end
-    end
-    return -2
-  end
-
-  local line = vim.api.nvim_get_current_line()
-  local col = vim.api.nvim_win_get_cursor(0)[2]
-  local trigger = ""
-
-  for i = math.min(col, #line), 1, -1 do
-    local ch = line:sub(i, i)
-    if ch == "@" or ch == "/" then
-      trigger = ch
-      break
-    end
-  end
-
-  local results = {}
-
-  if trigger == "@" then
-    local files = find_files(base)
-    for _, f in ipairs(files) do
-      table.insert(results, { word = f, menu = "[file]" })
-    end
-
-    local dirs = find_dirs(base)
-    for _, d in ipairs(dirs) do
-      table.insert(results, { word = d, menu = "[dir]" })
-    end
-  elseif trigger == "/" then
-    for _, cmd in ipairs(COMMANDS) do
-      if cmd.word:find(base, 1, true) == 1 then
-        table.insert(results, { word = cmd.word, menu = "[cmd]", info = cmd.info })
-      end
-    end
-  end
-
-  return results
+	return mentions.completefunc(findstart, base)
 end
 
 function M.expand_mentions(text)
-  local result = text
-
-  result = result:gsub("@([%w%_%-%./]+)/ ", function(path)
-    return "[directory: " .. path .. "/] "
-  end)
-
-  result = result:gsub("@([%w%_%-%./]+)", function(path)
-    local full_path = vim.fn.getcwd() .. "/" .. path
-    if vim.fn.filereadable(full_path) == 1 then
-      local bufnr = vim.fn.bufnr(full_path)
-      if bufnr ~= -1 then
-        local line = vim.api.nvim_win_get_cursor(0)[1]
-        return string.format("[file: %s, line: %d]", path, line)
-      end
-      return "[file: " .. path .. "]"
-    elseif vim.fn.isdirectory(full_path) == 1 then
-      return "[directory: " .. path .. "]"
-    end
-    return "@" .. path
-  end)
-
-  return result
+	return mentions.expand(text)
 end
 
 function M.validate_mentions(text)
-  local invalid = {}
-  for mention in text:gmatch("%[file: ([^%]]+)%]") do
-    local path = mention:gsub(", line: %d+", ""):gsub(", lines: %d+%-%d+", "")
-    local full = vim.fn.getcwd() .. "/" .. path
-    if vim.fn.filereadable(full) ~= 1 and vim.fn.isdirectory(full) ~= 1 then
-      table.insert(invalid, path)
-    end
-  end
-  return invalid
+	return mentions.validate(text)
 end
 
 function M.send_mention_for_buffer()
-  local buf = vim.api.nvim_get_current_buf()
-  local name = vim.api.nvim_buf_get_name(buf)
-  if name == "" then
-    vim.notify("No file for current buffer", vim.log.levels.WARN)
-    return nil
-  end
-
-  local rel = vim.fn.fnamemodify(name, ":.")
-  local mode = vim.api.nvim_get_mode().mode
-  local line1, line2
-
-  if mode:find("[vV\x16]") then
-    line1 = vim.fn.line("v")
-    line2 = vim.fn.line(".")
-    if line1 > line2 then
-      line1, line2 = line2, line1
-    end
-  else
-    line1 = vim.fn.line(".")
-    line2 = line1
-  end
-
-  if line1 == line2 then
-    return "[file: " .. rel .. ", line: " .. line1 .. "]"
-  else
-    return "[file: " .. rel .. ", lines: " .. line1 .. "-" .. line2 .. "]"
-  end
+	return mentions.insert_from_editor({})
 end
 
 return M

--- a/lua/tau/ui/prompt.lua
+++ b/lua/tau/ui/prompt.lua
@@ -1,116 +1,223 @@
 local M = {}
 
-local PROMPT_NS = vim.api.nvim_create_namespace("tau_prompt")
+local at_retrigger_timers = {}
+
+local function stop_at_retrigger(buf)
+	local id = at_retrigger_timers[buf]
+	if id then
+		pcall(vim.fn.timer_stop, id)
+		at_retrigger_timers[buf] = nil
+	end
+end
+
+local function attach_at_completion_retrigger(buf)
+	stop_at_retrigger(buf)
+	local ag = vim.api.nvim_create_augroup("tau_prompt_at_" .. tostring(buf), { clear = true })
+	vim.api.nvim_create_autocmd("TextChangedI", {
+		group = ag,
+		buffer = buf,
+		callback = function()
+			if vim.fn.pumvisible() == 1 then
+				return
+			end
+			local line = vim.api.nvim_get_current_line()
+			local col = vim.api.nvim_win_get_cursor(0)[2]
+			local before = line:sub(1, col)
+			local after_at_pos = before:match(".*@()")
+			if not after_at_pos then
+				return
+			end
+			local after_at = before:sub(after_at_pos)
+			if after_at == "" or after_at:find("%s") then
+				return
+			end
+			stop_at_retrigger(buf)
+			at_retrigger_timers[buf] = vim.fn.timer_start(50, 0, function()
+				at_retrigger_timers[buf] = nil
+				vim.schedule(function()
+					if not vim.api.nvim_buf_is_valid(buf) or vim.api.nvim_get_current_buf() ~= buf then
+						return
+					end
+					if vim.fn.mode() ~= "i" or vim.fn.pumvisible() == 1 then
+						return
+					end
+					vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<C-x><C-u>", true, true, true), "m", false)
+				end)
+			end)
+		end,
+	})
+end
 
 function M.create_buffer()
-  local buf = vim.api.nvim_create_buf(false, true)
-  vim.bo[buf].buftype = "nofile"
-  vim.bo[buf].bufhidden = "hide"
-  vim.bo[buf].swapfile = false
-  vim.bo[buf].filetype = "tau-prompt"
-  return buf
+	local buf = vim.api.nvim_create_buf(false, true)
+	vim.bo[buf].buftype = "nofile"
+	vim.bo[buf].bufhidden = "hide"
+	vim.bo[buf].swapfile = false
+	vim.bo[buf].filetype = "tau-prompt"
+	return buf
 end
 
 function M.get_text(buf)
-  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-  return table.concat(lines, "\n")
+	local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+	return table.concat(lines, "\n")
 end
 
 function M.clear(buf)
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, {})
+	vim.api.nvim_buf_set_lines(buf, 0, -1, false, {})
 end
 
 function M.set_keymaps(buf, callbacks)
-  callbacks = callbacks or {}
+	callbacks = callbacks or {}
 
-  local opts = { buffer = buf, silent = true }
+	local opts = { buffer = buf, silent = true }
 
-  vim.keymap.set({ "n", "i" }, "<C-CR>", function()
-    local text = M.get_text(buf)
-    if text and text:gsub("%s", "") ~= "" then
-      if callbacks.on_submit then
-        callbacks.on_submit(text)
-      end
-      M.clear(buf)
-    end
-  end, vim.tbl_extend("force", opts, { desc = "Submit prompt" }))
+	vim.keymap.set({ "n", "i" }, "<C-CR>", function()
+		local text = M.get_text(buf)
+		if text and text:gsub("%s", "") ~= "" then
+			if callbacks.on_submit then
+				callbacks.on_submit(text)
+			end
+			M.clear(buf)
+		end
+	end, vim.tbl_extend("force", opts, { desc = "Submit prompt" }))
 
-  vim.keymap.set("n", "<CR>", function()
-    local text = M.get_text(buf)
-    if text and text:gsub("%s", "") ~= "" then
-      if callbacks.on_submit then
-        callbacks.on_submit(text)
-      end
-      M.clear(buf)
-    end
-  end, vim.tbl_extend("force", opts, { desc = "Submit prompt" }))
+	vim.keymap.set("n", "<CR>", function()
+		local text = M.get_text(buf)
+		if text and text:gsub("%s", "") ~= "" then
+			if callbacks.on_submit then
+				callbacks.on_submit(text)
+			end
+			M.clear(buf)
+		end
+	end, vim.tbl_extend("force", opts, { desc = "Submit prompt" }))
 
-  vim.keymap.set("i", "<CR>", "<CR>", opts)
+	vim.keymap.set("i", "<CR>", "<CR>", opts)
 
-  vim.keymap.set("n", "q", function()
-    if callbacks.on_close then
-      callbacks.on_close()
-    end
-  end, vim.tbl_extend("force", opts, { desc = "Close chat" }))
+	vim.keymap.set("n", "q", function()
+		if callbacks.on_close then
+			callbacks.on_close()
+		end
+	end, vim.tbl_extend("force", opts, { desc = "Close chat" }))
 
-  vim.keymap.set("n", "<Esc>", function()
-    if callbacks.on_close then
-      callbacks.on_close()
-    end
-  end, vim.tbl_extend("force", opts, { desc = "Close chat" }))
+	vim.keymap.set("n", "<Esc>", function()
+		if callbacks.on_close then
+			callbacks.on_close()
+		end
+	end, vim.tbl_extend("force", opts, { desc = "Close chat" }))
 
-  vim.keymap.set({ "n", "i" }, "<C-h>", function()
-    if callbacks.on_focus_history then
-      callbacks.on_focus_history()
-    end
-  end, vim.tbl_extend("force", opts, { desc = "Focus history" }))
+	vim.keymap.set({ "n", "i" }, "<C-h>", function()
+		if callbacks.on_focus_history then
+			callbacks.on_focus_history()
+		end
+	end, vim.tbl_extend("force", opts, { desc = "Focus history" }))
 
-  vim.keymap.set({ "n", "i" }, "<C-z>", function()
-    if callbacks.on_zen then
-      callbacks.on_zen()
-    end
-  end, vim.tbl_extend("force", opts, { desc = "Toggle zen mode" }))
+	vim.keymap.set({ "n", "i" }, "<C-z>", function()
+		if callbacks.on_zen then
+			callbacks.on_zen()
+		end
+	end, vim.tbl_extend("force", opts, { desc = "Toggle zen mode" }))
+end
 
+local function merge_blink_tau_provider()
+	pcall(function()
+		require("blink.cmp.config").merge_with({
+			sources = {
+				providers = {
+					tau_mentions = {
+						name = "Tau mentions",
+						module = "tau.integrations.blink",
+						min_keyword_length = 0,
+						score_offset = 100,
+					},
+				},
+				per_filetype = {
+					["tau-prompt"] = { "tau_mentions", inherit_defaults = true },
+				},
+			},
+		})
+	end)
+end
 
+local function blink_tau_provider_configured()
+	local ok, cfg = pcall(require, "blink.cmp.config")
+	if not ok or not cfg or not cfg.sources or not cfg.sources.providers then
+		return false
+	end
+	return cfg.sources.providers.tau_mentions ~= nil
 end
 
 function M.set_completefunc(buf)
-  vim.bo[buf].completefunc = "v:lua.require'tau.ui.complete'.completefunc"
+	merge_blink_tau_provider()
+	local use_blink = blink_tau_provider_configured()
+
+	local function ensure_prompt_completion()
+		if not use_blink then
+			local ok_cmp, cmp = pcall(require, "cmp")
+			if ok_cmp and cmp and cmp.setup and cmp.setup.buffer then
+				cmp.setup.buffer({ enabled = false })
+			end
+		end
+		vim.bo.completefunc = "v:lua.__tau_completefunc"
+		local ok = pcall(function()
+			vim.bo.completeopt = "menuone,noinsert,popup"
+		end)
+		if not ok then
+			vim.bo.completeopt = "menuone,noinsert"
+		end
+	end
+
+	vim.api.nvim_buf_call(buf, ensure_prompt_completion)
+
+	local guard = vim.api.nvim_create_augroup("tau_prompt_complete_guard_" .. tostring(buf), { clear = true })
+	vim.api.nvim_create_autocmd({ "InsertEnter", "BufWinEnter" }, {
+		group = guard,
+		buffer = buf,
+		callback = function()
+			vim.api.nvim_buf_call(buf, ensure_prompt_completion)
+		end,
+	})
+
+	if not use_blink then
+		local map_opts = { buffer = buf, remap = true, silent = true }
+		vim.keymap.set("i", "@", "@<C-x><C-u>", map_opts)
+		vim.keymap.set("i", "<C-Space>", "<C-x><C-u>", map_opts)
+		attach_at_completion_retrigger(buf)
+	end
 end
 
 function M.set_statusline(win, text)
-  if not win or not vim.api.nvim_win_is_valid(win) then
-    return
-  end
-  text = text:gsub("[^%x20-%x7E]", "")
-  pcall(function()
-    vim.api.nvim_win_call(win, function()
-      vim.wo.statusline = text
-    end)
-  end)
+	if not win or not vim.api.nvim_win_is_valid(win) then
+		return
+	end
+	text = text:gsub("[^%x20-%x7E]", "")
+	pcall(function()
+		vim.api.nvim_win_call(win, function()
+			vim.wo.statusline = text
+		end)
+	end)
 end
 
 function M.build_statusline(session, config)
-  if not session then
-    return " tau "
-  end
+	if not session then
+		return " tau "
+	end
 
-  local parts = {}
-  local model = session.model or "default"
-  table.insert(parts, " " .. model .. " ")
+	local parts = {}
+	local model = session.model or "default"
+	table.insert(parts, " " .. model .. " ")
 
-  local thinking = require("tau.models").get_thinking_level()
-  if thinking and thinking ~= "off" then
-    table.insert(parts, "[think:" .. thinking .. "]")
-  end
+	local thinking = require("tau.models").get_thinking_level()
+	if thinking and thinking ~= "off" then
+		table.insert(parts, "[think:" .. thinking .. "]")
+	end
 
-  local ctx = require("tau.state").get_token_info()
-  if ctx then
-    local pct = math.floor(ctx.ratio * 100)
-    table.insert(parts, string.format(" %d%% (%d/%d)", pct, ctx.used, ctx.limit))
-  end
+	local ctx = require("tau.state").get_token_info()
+	if ctx then
+		local pct = math.floor(ctx.ratio * 100)
+		table.insert(parts, string.format(" %d%% (%d/%d)", pct, ctx.used, ctx.limit))
+	end
 
-  return table.concat(parts, " ")
+	return table.concat(parts, " ")
 end
 
 return M

--- a/plugin/tau.lua
+++ b/plugin/tau.lua
@@ -3,6 +3,16 @@ if vim.g.tau_loaded then
 end
 vim.g.tau_loaded = true
 
+_G.__tau_completefunc = function(findstart, base)
+	return require("tau.ui.complete").completefunc(findstart, base)
+end
+
+vim.schedule(function()
+	pcall(function()
+		require("tau.mentions").ensure_default()
+	end)
+end)
+
 local cmd = vim.api.nvim_create_user_command
 
 cmd("Tau", function(opts)
@@ -123,9 +133,13 @@ cmd("TauZen", function()
 	require("tau.ui.zen").toggle()
 end, { nargs = 0, desc = "Toggle zen mode" })
 
+cmd("TauPromptContext", function()
+	require("tau").insert_prompt_context({})
+end, { nargs = 0, desc = "Insert file/selection context into Tau prompt" })
+
 cmd("TauSendMention", function()
-	require("tau").send_mention()
-end, { nargs = 0, desc = "Insert @mention for current buffer/selection" })
+	require("tau").insert_prompt_context({})
+end, { nargs = 0, desc = "Alias for :TauPromptContext" })
 
 cmd("TauAgents", function()
 	require("tau").show_agents()


### PR DESCRIPTION
### Summary
  Improves Tau’s prompt file mentions so they work with **blink.cmp**, drops unused slash-command
  completion, fixes cursor math for `@` completion, and inserts **`[file: …]` / `[directory: …]`**
  (with `./` where appropriate) when a completion is accepted, so the prompt shows the same mention
  shape the session uses after expand.
### Changes
#### blink.cmp
  - Add **`lua/tau/integrations/blink.lua`**, a thin wrapper around blink’s `complete_func` source
  that only activates for **`tau-prompt`** and delegates to **`v:lua.__tau_completefunc`**.
  - On **`set_completefunc`**, merge blink config to register provider **`tau_mentions`** and set
  **`per_filetype["tau-prompt"]`** so **`tau_mentions`** runs together with inherited default
  sources.
  - When that provider is present, the prompt **does not** map `@` / `<C-Space>` to `<C-x><C-u>`
  (blink owns completion); otherwise the previous nvim-cmp / user-completion fallback remains.
#### Mentions / files provider
  - **`normalize_base`** strips a leading **`@`** so bases from blink/native completion stay
  consistent.
  - Fix **`@` detection** by using **1-based** indices into the current line (`col0 + 1`) in both
  **`complete_at`** and **`mentions.completefunc`**, matching Neovim’s 0-based cursor column.
  #### Prompt keymaps / compatibility
  - Remove **`priority`** from **`vim.keymap.set`** options (unsupported on some Neovim builds;
  fixes **`invalid key: priority`**).
  - Remove the **`/`** expr mapping that triggered slash completion.
  #### Completion insert format
  - File completions insert **`[file: ./relative/path]`** (or an already-absolute/normalized path
  when applicable).
  - Directory completions insert **`[directory: ./relative/path]`**.
  - **`abbr`** keeps a short path for the menu; **`word`** is the full bracket mention. **`expand`**
   still only rewrites **`@…`**, so these brackets are not double-processed on submit.
  #### Health
  - **`TauCheckHealth`** reports whether **`tau_mentions`** appears in blink’s merged config when
  blink is available.