### PR TITLE
2 phase 7 session management

### DIFF
--- a/lua/tau/api.lua
+++ b/lua/tau/api.lua
@@ -38,6 +38,7 @@ local function get_model(provider_name)
 end
 
 function M.stream(provider_name, messages, opts)
+	opts = opts or {}
 	local plugin = plugins.get_provider(provider_name)
 	if not plugin then
 		error("Unknown provider: " .. provider_name)
@@ -45,12 +46,13 @@ function M.stream(provider_name, messages, opts)
 
 	local api_key = get_api_key(provider_name)
 	local base_url = get_base_url(provider_name)
-	local model = get_model(provider_name)
+	local model = opts.model or get_model(provider_name)
 
 	return plugin.stream(api_key, base_url, model, messages, opts)
 end
 
 function M.call(provider_name, messages, opts)
+	opts = opts or {}
 	local plugin = plugins.get_provider(provider_name)
 	if not plugin then
 		error("Unknown provider: " .. provider_name)
@@ -58,7 +60,7 @@ function M.call(provider_name, messages, opts)
 
 	local api_key = get_api_key(provider_name)
 	local base_url = get_base_url(provider_name)
-	local model = get_model(provider_name)
+	local model = opts.model or get_model(provider_name)
 
 	return plugin.call(api_key, base_url, model, messages, opts)
 end

--- a/lua/tau/config.lua
+++ b/lua/tau/config.lua
@@ -102,7 +102,7 @@ local defaults = {
 	on_widget = nil,
 
 	session = {
-		auto_llm_title = true,
+		auto_llm_title = false,
 		title_max_chars_excerpt = 4000,
 		title_max_length = 56,
 		title_model = nil,

--- a/lua/tau/config.lua
+++ b/lua/tau/config.lua
@@ -100,6 +100,13 @@ local defaults = {
 	},
 
 	on_widget = nil,
+
+	session = {
+		auto_llm_title = true,
+		title_max_chars_excerpt = 4000,
+		title_max_length = 56,
+		title_model = nil,
+	},
 }
 
 local active = nil

--- a/lua/tau/init.lua
+++ b/lua/tau/init.lua
@@ -70,6 +70,11 @@ function M.new_session(opts)
 
 	state.set_session(nil, session)
 	require("tau.session").TauSessionAutosave(session)
+	local ui = require("tau.ui")
+	if ui.active then
+		ui.active.session = session
+		ui.refresh()
+	end
 	if not opts.silent then
 		vim.notify("New session started", vim.log.levels.INFO)
 	end
@@ -369,6 +374,10 @@ end
 
 function M.session_info()
 	require("tau.session").TauSessionInfo()
+end
+
+function M.generate_session_title(opts)
+	require("tau.session_title").generate_now(opts or {})
 end
 
 function M.TauSessionTree()

--- a/lua/tau/init.lua
+++ b/lua/tau/init.lua
@@ -5,6 +5,7 @@ local config = require("tau.config")
 function M.setup(opts)
 	opts = opts or {}
 	config.setup(opts)
+	require("tau.session_storage").TauEnsureBuiltinRegistered()
 	require("tau.plugin").init({ plugins = opts.plugins })
 	require("tau.mentions").init({
 		mention_plugins = opts.mention_plugins or {},
@@ -47,7 +48,8 @@ function M.abort()
 	require("tau.rpc").abort()
 end
 
-function M.new_session()
+function M.new_session(opts)
+	opts = opts or {}
 	local state = require("tau.state")
 	local agents = require("tau.agents")
 	local tauConfig = require("tau.config").get()
@@ -67,7 +69,10 @@ function M.new_session()
 	end
 
 	state.set_session(nil, session)
-	vim.notify("New session started", vim.log.levels.INFO)
+	require("tau.session").TauSessionAutosave(session)
+	if not opts.silent then
+		vim.notify("New session started", vim.log.levels.INFO)
+	end
 end
 
 function M.continue_session()
@@ -75,7 +80,7 @@ function M.continue_session()
 end
 
 function M.resume_session()
-	require("tau.session").list_sessions(vim.fn.getcwd())
+	require("tau.session").pick_and_load(vim.fn.getcwd())
 end
 
 function M.compact(instructions)
@@ -97,6 +102,7 @@ function M.compact(instructions)
 	session.messages = compacted
 	session.compacted_count = (session.compacted_count or 0) + 1
 	state.update_session_tokens()
+	require("tau.session").TauSessionAutosave(session)
 
 	local after = context.count_messages_tokens(session.messages)
 	vim.notify(
@@ -331,6 +337,50 @@ end
 
 function M.register_provider(plugin_module)
 	require("tau.plugin").register_provider(plugin_module)
+end
+
+function M.register_session_storage(name, provider)
+	require("tau.session_storage").TauRegisterSessionStorage(name, provider)
+end
+
+function M.set_session_storage(name)
+	return require("tau.session_storage").TauSetSessionStorage(name)
+end
+
+function M.get_session_storage()
+	return require("tau.session_storage").TauGetSessionStorage()
+end
+
+M.TauRegisterSessionStorage = M.register_session_storage
+M.TauSetSessionStorage = M.set_session_storage
+M.TauGetSessionStorage = M.get_session_storage
+
+function M.end_session()
+	require("tau.session").TauSessionEnd()
+end
+
+function M.set_session_name(name)
+	require("tau.session").TauSessionSetName(name)
+end
+
+function M.export_session_html(path)
+	require("tau.session").TauSessionExportHtml(path)
+end
+
+function M.session_info()
+	require("tau.session").TauSessionInfo()
+end
+
+function M.TauSessionTree()
+	require("tau.session").TauSessionTree()
+end
+
+function M.TauSessionFork(message_index)
+	require("tau.session").TauSessionFork(message_index)
+end
+
+function M.TauSessionClone()
+	require("tau.session").TauSessionClone()
 end
 
 function M.get_mention_provider()

--- a/lua/tau/rpc.lua
+++ b/lua/tau/rpc.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+function M.stop()
+	require("tau.dispatcher").stop()
+end
+
+function M.abort()
+	require("tau.dispatcher").stop()
+end
+
+return M

--- a/lua/tau/session.lua
+++ b/lua/tau/session.lua
@@ -1,0 +1,285 @@
+local M = {}
+
+local layout = require("tau.ui.layout")
+
+local function store()
+	require("tau.session_storage").TauEnsureBuiltinRegistered()
+	return select(1, require("tau.session_storage").TauGetSessionStorage())
+end
+
+function M.TauSessionAutosave(session)
+	if not session then
+		return
+	end
+	local ok, err = store().save_session(session)
+	if not ok then
+		vim.notify(tostring(err or "session save failed"), vim.log.levels.WARN)
+	end
+end
+
+function M.load_most_recent(cwd)
+	cwd = vim.fs.normalize(cwd or vim.fn.getcwd())
+	local list = store().list_sessions(cwd)
+	if not list or #list == 0 then
+		vim.notify("No saved sessions for this directory", vim.log.levels.WARN)
+		return
+	end
+	local top = list[1]
+	local session = store().load_session(cwd, top.id)
+	if not session then
+		vim.notify("Failed to load session", vim.log.levels.ERROR)
+		return
+	end
+	require("tau.state").set_session(nil, session)
+	local ui = require("tau.ui")
+	if ui.active and layout.is_open(ui.active.layout_state) then
+		ui.active.session = session
+		ui.refresh()
+	else
+		ui.open({ resume = true })
+	end
+	vim.notify("Continued session " .. (session.name or session.id), vim.log.levels.INFO)
+end
+
+function M.pick_and_load(cwd)
+	cwd = vim.fs.normalize(cwd or vim.fn.getcwd())
+	local list = store().list_sessions(cwd)
+	if not list or #list == 0 then
+		vim.notify("No saved sessions for this directory", vim.log.levels.WARN)
+		return
+	end
+	local active_s = require("tau.state").get_session()
+	local labels = {}
+	for _, item in ipairs(list) do
+		local name = item.name and item.name ~= "" and item.name or item.id
+		local ts = item.updated_at or item.created_at
+		local t = ts and ts > 0 and os.date("%Y-%m-%d %H:%M", ts) or "?"
+		local marker = active_s and active_s.id == item.id and "> " or "  "
+		table.insert(
+			labels,
+			string.format("%s%s  |  edited %s  |  %d msgs", marker, name, t, item.message_count or 0)
+		)
+	end
+	vim.ui.select(labels, {
+		prompt = "Select session",
+	}, function(_, idx)
+		if not idx then
+			return
+		end
+		local item = list[idx]
+		if not item then
+			return
+		end
+		local session = store().load_session(cwd, item.id)
+		if not session then
+			vim.notify("Failed to load session", vim.log.levels.ERROR)
+			return
+		end
+		require("tau.state").set_session(nil, session)
+		local ui = require("tau.ui")
+		if ui.active and layout.is_open(ui.active.layout_state) then
+			ui.active.session = session
+			ui.refresh()
+		else
+			ui.open({ resume = true })
+		end
+		vim.notify("Loaded session " .. (session.name or session.id), vim.log.levels.INFO)
+	end)
+end
+
+function M.TauSessionSetName(name)
+	name = (name or ""):gsub("^%s+", ""):gsub("%s+$", "")
+	if name == "" then
+		vim.notify("TauSessionSetName: empty name", vim.log.levels.WARN)
+		return
+	end
+	local session = require("tau.state").get_session()
+	if not session then
+		vim.notify("No active session", vim.log.levels.WARN)
+		return
+	end
+	session.name = name
+	M.TauSessionAutosave(session)
+	vim.notify("Session name set", vim.log.levels.INFO)
+end
+
+function M.TauSessionEnd()
+	require("tau.dispatcher").stop()
+	require("tau.ui").close()
+	require("tau.state").clear_session()
+	vim.notify("Tau session ended", vim.log.levels.INFO)
+end
+
+local function html_escape(s)
+	if type(s) ~= "string" then
+		return ""
+	end
+	return s
+		:gsub("&", "&amp;")
+		:gsub("<", "&lt;")
+		:gsub(">", "&gt;")
+		:gsub('"', "&quot;")
+end
+
+function M.TauSessionExportHtml(path)
+	path = (path or ""):gsub("^%s+", ""):gsub("%s+$", "")
+	if path == "" then
+		vim.notify("TauSessionExportHtml: need file path", vim.log.levels.WARN)
+		return
+	end
+	local session = require("tau.state").get_session()
+	if not session then
+		vim.notify("No active session", vim.log.levels.WARN)
+		return
+	end
+	local lines = {
+		"<!DOCTYPE html>",
+		"<html><head><meta charset=\"utf-8\"><title>"
+			.. html_escape(session.name or session.id)
+			.. "</title></head><body>",
+		"<h1>"
+			.. html_escape(session.name or session.id)
+			.. "</h1>",
+		"<pre>",
+	}
+	for _, msg in ipairs(session.messages or {}) do
+		local role = html_escape(tostring(msg.role or "?"))
+		local content = msg.content
+		if type(content) == "string" then
+			content = html_escape(content)
+		else
+			content = html_escape(vim.json.encode(content))
+		end
+		table.insert(lines, "[" .. role .. "]\n" .. content .. "\n")
+	end
+	table.insert(lines, "</pre></body></html>")
+	vim.fn.writefile(lines, path)
+	vim.notify("Exported to " .. path, vim.log.levels.INFO)
+end
+
+function M.TauSessionInfo()
+	local session = require("tau.state").get_session()
+	if not session then
+		vim.notify("No active session", vim.log.levels.WARN)
+		return
+	end
+	require("tau.state").update_session_tokens()
+	local path = session._storage_path or "not saved yet"
+	local n = #(session.messages or {})
+	local cost = session.cost_usd
+	local cost_str = cost and tostring(cost) or "n/a"
+	local lines = {
+		"id: " .. tostring(session.id),
+		"name: " .. tostring(session.name or ""),
+		"cwd: " .. tostring(session.cwd),
+		"file: " .. tostring(path),
+		"messages: " .. tostring(n),
+		"tokens: " .. tostring(session.tokens_used or 0) .. " / " .. tostring(session.context_limit or 0),
+		"cost_usd: " .. cost_str,
+	}
+	vim.notify(table.concat(lines, "\n"), vim.log.levels.INFO)
+end
+
+function M.TauSessionFork(message_index)
+	local state = require("tau.state")
+	local session = state.get_session()
+	if not session then
+		vim.notify("No active session", vim.log.levels.WARN)
+		return
+	end
+	local msgs = session.messages or {}
+	local n = #msgs
+	if n == 0 then
+		vim.notify("No messages to fork from", vim.log.levels.WARN)
+		return
+	end
+	message_index = message_index or n
+	if message_index < 1 or message_index > n then
+		vim.notify("Invalid message index", vim.log.levels.WARN)
+		return
+	end
+	local tauConfig = require("tau.config").get()
+	local agents = require("tau.agents")
+	local parent_id = session.id
+	local new_msgs = {}
+	for i = 1, message_index do
+		table.insert(new_msgs, vim.deepcopy(msgs[i]))
+	end
+	local new_session = state.create_session({
+		cwd = session.cwd,
+		provider = session.provider or tauConfig.provider.name,
+		model = session.model or tauConfig.provider.model,
+		messages = new_msgs,
+		parent_id = parent_id,
+	})
+	new_session._storage_path = nil
+	state.set_session(nil, new_session)
+	M.TauSessionAutosave(new_session)
+	local ui = require("tau.ui")
+	if ui.active then
+		ui.active.session = new_session
+		ui.refresh()
+	end
+	vim.notify("Forked session from message " .. tostring(message_index), vim.log.levels.INFO)
+end
+
+function M.TauSessionClone()
+	local state = require("tau.state")
+	local session = state.get_session()
+	if not session then
+		vim.notify("No active session", vim.log.levels.WARN)
+		return
+	end
+	local tauConfig = require("tau.config").get()
+	local new_session = state.create_session({
+		cwd = session.cwd,
+		provider = session.provider or tauConfig.provider.name,
+		model = session.model or tauConfig.provider.model,
+		messages = vim.deepcopy(session.messages or {}),
+		parent_id = session.parent_id,
+	})
+	new_session.name = session.name and (session.name .. " (copy)") or nil
+	new_session._storage_path = nil
+	state.set_session(nil, new_session)
+	M.TauSessionAutosave(new_session)
+	local ui = require("tau.ui")
+	if ui.active then
+		ui.active.session = new_session
+		ui.refresh()
+	end
+	vim.notify("Cloned session", vim.log.levels.INFO)
+end
+
+function M.TauSessionTree()
+	local state = require("tau.state")
+	local session = state.get_session()
+	if not session then
+		vim.notify("No active session", vim.log.levels.WARN)
+		return
+	end
+	local msgs = session.messages or {}
+	local choices = {}
+	local indices = {}
+	for i, msg in ipairs(msgs) do
+		if msg.role == "user" or msg.role == "assistant" then
+			local preview = type(msg.content) == "string" and msg.content or vim.json.encode(msg.content)
+			preview = preview:gsub("\n", " ")
+			if #preview > 60 then
+				preview = preview:sub(1, 60) .. "…"
+			end
+			table.insert(choices, string.format("%d [%s] %s", i, msg.role, preview))
+			table.insert(indices, i)
+		end
+	end
+	if #choices == 0 then
+		vim.notify("No user/assistant messages in tree", vim.log.levels.WARN)
+		return
+	end
+	vim.ui.select(choices, { prompt = "Continue from message (fork)" }, function(_, idx)
+		if idx then
+			M.TauSessionFork(indices[idx])
+		end
+	end)
+end
+
+return M

--- a/lua/tau/session.lua
+++ b/lua/tau/session.lua
@@ -9,12 +9,13 @@ end
 
 function M.TauSessionAutosave(session)
 	if not session then
-		return
+		return false, "no session"
 	end
 	local ok, err = store().save_session(session)
 	if not ok then
 		vim.notify(tostring(err or "session save failed"), vim.log.levels.WARN)
 	end
+	return ok, err
 end
 
 function M.load_most_recent(cwd)

--- a/lua/tau/session_display.lua
+++ b/lua/tau/session_display.lua
@@ -1,0 +1,38 @@
+local M = {}
+
+function M.winbar_text(session)
+	local cfg = require("tau.config").get()
+	local provider_name = session and session.provider or cfg.provider.name or "default"
+	local model = session and session.model or cfg.provider.model
+	if not model then
+		model = require("tau.models").get_active()
+	end
+	if not model then
+		local plugin = require("tau.plugin").get_provider(provider_name)
+		if plugin then
+			model = plugin.default_model
+		end
+	end
+	if not model then
+		local fallback = require("tau.plugin").get_fallback_models(provider_name)
+		if fallback and #fallback > 0 then
+			model = fallback[1]
+		end
+	end
+	local title = "…"
+	if session then
+		if session.name and session.name ~= "" then
+			title = session.name
+		else
+			local id = session.id or ""
+			if #id > 16 then
+				title = id:sub(1, 16) .. "…"
+			elseif id ~= "" then
+				title = id
+			end
+		end
+	end
+	return string.format(" %s · %s | %s ", title, provider_name, model or "default")
+end
+
+return M

--- a/lua/tau/session_storage.lua
+++ b/lua/tau/session_storage.lua
@@ -166,10 +166,14 @@ function builtin.load_session(cwd, session_id)
 	if not session_meta then
 		return nil
 	end
+	local loaded_name = session_meta.name
+	if type(loaded_name) ~= "string" or loaded_name == "" then
+		loaded_name = nil
+	end
 	return {
 		id = session_meta.id,
 		cwd = session_meta.cwd,
-		name = session_meta.name,
+		name = loaded_name,
 		parent_id = session_meta.parent_id,
 		messages = messages,
 		model = session_meta.model,
@@ -196,11 +200,15 @@ function builtin.save_session(session)
 	local model = session.model or require("tau.config").get().provider.model
 	session.tokens_used = context.count_messages_tokens(session.messages or {})
 	session.context_limit = context.get_context_limit(model)
+	local name_str = nil
+	if type(session.name) == "string" and session.name ~= "" then
+		name_str = session.name
+	end
 	local head = {
 		kind = "session",
 		id = session.id,
 		cwd = session.cwd,
-		name = session.name,
+		name = name_str,
 		parent_id = session.parent_id,
 		model = session.model,
 		provider = session.provider,
@@ -215,7 +223,26 @@ function builtin.save_session(session)
 	for _, msg in ipairs(session.messages or {}) do
 		table.insert(lines, vim.json.encode({ kind = "message", msg = msg }))
 	end
-	vim.fn.writefile(lines, path)
+	local wok, werr = pcall(vim.fn.writefile, lines, path, "s")
+	if not wok then
+		wok, werr = pcall(vim.fn.writefile, lines, path)
+	end
+	if not wok then
+		return false, tostring(werr or "writefile failed")
+	end
+	if name_str then
+		local verify = vim.fn.readfile(path)
+		if not verify or verify[1] == nil or verify[1] == "" then
+			return false, "session file empty after write"
+		end
+		local dec_ok, meta = pcall(vim.json.decode, verify[1])
+		if not dec_ok or type(meta) ~= "table" or meta.kind ~= "session" then
+			return false, "session header corrupt after write"
+		end
+		if meta.name ~= name_str then
+			return false, "session name missing in file (got " .. tostring(meta.name) .. ")"
+		end
+	end
 	return true
 end
 

--- a/lua/tau/session_storage.lua
+++ b/lua/tau/session_storage.lua
@@ -1,0 +1,261 @@
+local M = {}
+
+local registry = {}
+local active = nil
+local BUILTIN = "jsonl"
+
+local function ensure_dirs(path)
+	local dir = vim.fn.fnamemodify(path, ":h")
+	if vim.fn.isdirectory(dir) == 0 then
+		vim.fn.mkdir(dir, "p")
+	end
+end
+
+local function cwd_key(cwd)
+	cwd = vim.fs.normalize(cwd or "")
+	local sum = 5381
+	local cap = math.min(#cwd, 8192)
+	for i = 1, cap do
+		sum = (sum * 33 + string.byte(cwd, i)) % 2147483647
+	end
+	return string.format("%08x", sum)
+end
+
+local function sessions_root()
+	return vim.fs.joinpath(vim.fn.stdpath("state"), "tau", "sessions")
+end
+
+local function session_file_path(cwd, session_id)
+	local key = cwd_key(cwd)
+	local safe_id = session_id:gsub("[^%w%-_%.]", "_")
+	return vim.fs.joinpath(sessions_root(), key, safe_id .. ".jsonl")
+end
+
+function M.TauRegisterSessionStorage(name, provider)
+	if type(name) ~= "string" or name == "" then
+		vim.notify("TauRegisterSessionStorage: invalid name", vim.log.levels.ERROR)
+		return
+	end
+	if type(provider) ~= "table" then
+		vim.notify("TauRegisterSessionStorage: provider must be a table", vim.log.levels.ERROR)
+		return
+	end
+	for _, key in ipairs({ "list_sessions", "load_session", "save_session", "delete_session" }) do
+		if type(provider[key]) ~= "function" then
+			vim.notify(
+				"TauRegisterSessionStorage: provider must implement " .. key,
+				vim.log.levels.ERROR
+			)
+			return
+		end
+	end
+	registry[name] = provider
+	if not active then
+		active = name
+	end
+end
+
+function M.TauSetSessionStorage(name)
+	if not registry[name] then
+		vim.notify("Tau: unknown session storage '" .. tostring(name) .. "'", vim.log.levels.ERROR)
+		return false
+	end
+	active = name
+	return true
+end
+
+function M.TauGetSessionStorage()
+	if not active or not registry[active] then
+		M.TauEnsureBuiltinRegistered()
+	end
+	return registry[active], active
+end
+
+function M.TauListSessionStorageNames()
+	local names = {}
+	for k in pairs(registry) do
+		table.insert(names, k)
+	end
+	table.sort(names)
+	return names
+end
+
+local builtin = {}
+
+function builtin.read_meta(path)
+	local lines = vim.fn.readfile(path)
+	if not lines or #lines == 0 then
+		return nil
+	end
+	local ok, obj = pcall(vim.json.decode, lines[1])
+	if ok and obj and obj.kind == "session" then
+		return obj
+	end
+	return nil
+end
+
+function builtin.list_sessions(cwd)
+	cwd = vim.fs.normalize(cwd or vim.fn.getcwd())
+	local dir = vim.fs.joinpath(sessions_root(), cwd_key(cwd))
+	if vim.fn.isdirectory(dir) == 0 then
+		return {}
+	end
+	local files = vim.fn.globpath(dir, "*.jsonl", false, true)
+	if type(files) == "string" then
+		files = { files }
+	end
+	local out = {}
+	for _, path in ipairs(files) do
+		if path ~= "" then
+			local meta = builtin.read_meta(path)
+			if meta and vim.fs.normalize(meta.cwd or "") == cwd then
+				local raw = vim.fn.readfile(path)
+				local msg_count = 0
+				for i = 2, #raw do
+					local line = raw[i]
+					if line and line ~= "" then
+						local ok, obj = pcall(vim.json.decode, line)
+						if ok and obj and obj.kind == "message" then
+							msg_count = msg_count + 1
+						end
+					end
+				end
+				table.insert(out, {
+					id = meta.id,
+					name = meta.name,
+					cwd = meta.cwd,
+					created_at = meta.created_at or 0,
+					updated_at = meta.updated_at or meta.created_at or 0,
+					message_count = msg_count,
+					path = path,
+				})
+			end
+		end
+	end
+	table.sort(out, function(a, b)
+		local ua = a.updated_at or 0
+		local ub = b.updated_at or 0
+		if ua ~= ub then
+			return ua > ub
+		end
+		return (a.created_at or 0) > (b.created_at or 0)
+	end)
+	return out
+end
+
+function builtin.load_session(cwd, session_id)
+	local path = session_file_path(cwd, session_id)
+	if vim.fn.filereadable(path) ~= 1 then
+		return nil
+	end
+	local lines = vim.fn.readfile(path)
+	local session_meta = nil
+	local messages = {}
+	for _, line in ipairs(lines) do
+		if line ~= "" then
+			local ok, obj = pcall(vim.json.decode, line)
+			if ok and obj then
+				if obj.kind == "session" then
+					session_meta = obj
+				elseif obj.kind == "message" and obj.msg then
+					table.insert(messages, obj.msg)
+				end
+			end
+		end
+	end
+	if not session_meta then
+		return nil
+	end
+	return {
+		id = session_meta.id,
+		cwd = session_meta.cwd,
+		name = session_meta.name,
+		parent_id = session_meta.parent_id,
+		messages = messages,
+		model = session_meta.model,
+		provider = session_meta.provider,
+		tokens_used = session_meta.tokens_used or 0,
+		context_limit = session_meta.context_limit or 0,
+		compacted_count = session_meta.compacted_count or 0,
+		created_at = session_meta.created_at,
+		updated_at = session_meta.updated_at,
+		cost_usd = session_meta.cost_usd,
+		_storage_path = path,
+	}
+end
+
+function builtin.save_session(session)
+	if not session or not session.id or not session.cwd then
+		return false, "no session"
+	end
+	session.updated_at = vim.fn.localtime()
+	local path = session._storage_path or session_file_path(session.cwd, session.id)
+	session._storage_path = path
+	ensure_dirs(path)
+	local context = require("tau.context")
+	local model = session.model or require("tau.config").get().provider.model
+	session.tokens_used = context.count_messages_tokens(session.messages or {})
+	session.context_limit = context.get_context_limit(model)
+	local head = {
+		kind = "session",
+		id = session.id,
+		cwd = session.cwd,
+		name = session.name,
+		parent_id = session.parent_id,
+		model = session.model,
+		provider = session.provider,
+		tokens_used = session.tokens_used,
+		context_limit = session.context_limit,
+		compacted_count = session.compacted_count or 0,
+		created_at = session.created_at,
+		updated_at = session.updated_at,
+		cost_usd = session.cost_usd,
+	}
+	local lines = { vim.json.encode(head) }
+	for _, msg in ipairs(session.messages or {}) do
+		table.insert(lines, vim.json.encode({ kind = "message", msg = msg }))
+	end
+	vim.fn.writefile(lines, path)
+	return true
+end
+
+function builtin.delete_session(cwd, session_id)
+	local path = session_file_path(cwd, session_id)
+	if vim.fn.filereadable(path) == 1 then
+		vim.fn.delete(path)
+		return true
+	end
+	return false
+end
+
+function M.TauEnsureBuiltinRegistered()
+	if registry[BUILTIN] then
+		if not active then
+			active = BUILTIN
+		end
+		return
+	end
+	registry[BUILTIN] = {
+		list_sessions = function(cwd)
+			return builtin.list_sessions(cwd)
+		end,
+		load_session = function(cwd, sid)
+			return builtin.load_session(cwd, sid)
+		end,
+		save_session = function(s)
+			return builtin.save_session(s)
+		end,
+		delete_session = function(cwd, sid)
+			return builtin.delete_session(cwd, sid)
+		end,
+	}
+	if not active then
+		active = BUILTIN
+	end
+end
+
+M._sessions_root = sessions_root
+M._cwd_key = cwd_key
+M._session_file_path = session_file_path
+
+return M

--- a/lua/tau/session_title.lua
+++ b/lua/tau/session_title.lua
@@ -1,0 +1,216 @@
+local M = {}
+
+local function message_text(content)
+	if type(content) == "string" then
+		return content
+	end
+	if content == nil then
+		return ""
+	end
+	local ok, enc = pcall(vim.json.encode, content)
+	if ok then
+		return enc
+	end
+	return ""
+end
+
+local function excerpt_from_messages(msgs, max_chars)
+	max_chars = max_chars or 4000
+	local parts = {}
+	local n = 0
+	for _, m in ipairs(msgs or {}) do
+		if m.role ~= "system" then
+			local text = message_text(m.content)
+			if m.role == "assistant" and type(m.reasoning_content) == "string" and m.reasoning_content ~= "" then
+				text = text ~= "" and (text .. "\n" .. m.reasoning_content) or m.reasoning_content
+			end
+			if text ~= "" then
+				local line = (m.role or "?") .. ": " .. text
+				if n + #line > max_chars then
+					local rest = max_chars - n
+					if rest > 0 then
+						table.insert(parts, line:sub(1, rest))
+					end
+					break
+				end
+				table.insert(parts, line)
+				n = n + #line + 1
+			end
+		end
+	end
+	return table.concat(parts, "\n")
+end
+
+local function sanitize_title(s, max_len)
+	if not s then
+		return ""
+	end
+	s = s:gsub("^%s+", ""):gsub("%s+$", "")
+	s = s:gsub('^["\']', ""):gsub('["\']$', "")
+	s = s:gsub("[\r\n]+", " ")
+	s = s:gsub("%s+", " ")
+	if #s > max_len then
+		s = s:sub(1, max_len)
+	end
+	return s:gsub("^%s+", ""):gsub("%s+$", "")
+end
+
+local function has_assistant_reply(msgs)
+	for _, m in ipairs(msgs or {}) do
+		if m.role == "assistant" then
+			local t = message_text(m.content)
+			if t == "" and type(m.reasoning_content) == "string" and m.reasoning_content ~= "" then
+				t = m.reasoning_content
+			end
+			if t ~= "" then
+				return true
+			end
+			if type(m.tool_calls) == "table" and #m.tool_calls > 0 then
+				return true
+			end
+		end
+	end
+	return false
+end
+
+function M._run(expected_session_id)
+	local state = require("tau.state")
+	local session = state.get_session()
+	if not session or session.id ~= expected_session_id then
+		return
+	end
+	local cfg = require("tau.config").get()
+	local scfg = cfg.session or {}
+	if not scfg.auto_llm_title then
+		return
+	end
+	if session.name and session.name ~= "" then
+		return
+	end
+	if session._tau_llm_title_done then
+		return
+	end
+	if not has_assistant_reply(session.messages) then
+		return
+	end
+
+	local excerpt = excerpt_from_messages(session.messages, scfg.title_max_chars_excerpt)
+	if excerpt == "" then
+		session._tau_llm_title_done = true
+		return
+	end
+
+	local provider = session.provider or cfg.provider.name
+	local max_len = scfg.title_max_length or 56
+	local sys =
+		"You name chat sessions. Output exactly one short title: 3-7 words, no quotes, no colons, no newlines, describe the user topic or task only."
+	local messages = {
+		{ role = "system", content = sys },
+		{ role = "user", content = excerpt },
+	}
+
+	local call_opts = {
+		max_tokens = 64,
+		thinking_level = "off",
+	}
+	if scfg.title_model and scfg.title_model ~= "" then
+		call_opts.model = scfg.title_model
+	end
+
+	local ok, result = pcall(require("tau.api").call, provider, messages, call_opts)
+	if not ok then
+		session._tau_llm_title_attempts = (session._tau_llm_title_attempts or 0) + 1
+		if session._tau_llm_title_attempts >= 2 then
+			session._tau_llm_title_done = true
+			vim.notify("Tau session title failed: " .. tostring(result), vim.log.levels.WARN)
+		end
+		return
+	end
+	local raw_title = ""
+	if type(result.text) == "string" and result.text ~= "" then
+		raw_title = result.text
+	elseif type(result.thinking) == "string" and result.thinking ~= "" then
+		raw_title = result.thinking
+	end
+	if raw_title == "" then
+		session._tau_llm_title_attempts = (session._tau_llm_title_attempts or 0) + 1
+		if session._tau_llm_title_attempts >= 2 then
+			session._tau_llm_title_done = true
+			vim.notify("Tau session title: empty model reply", vim.log.levels.WARN)
+		end
+		return
+	end
+
+	local title = sanitize_title(raw_title, max_len)
+	if title == "" then
+		session._tau_llm_title_attempts = (session._tau_llm_title_attempts or 0) + 1
+		if session._tau_llm_title_attempts >= 2 then
+			session._tau_llm_title_done = true
+		end
+		return
+	end
+
+	session.name = title
+	session._tau_llm_title_done = true
+	local saved, save_err = require("tau.session").TauSessionAutosave(session)
+	if saved == false then
+		session._tau_llm_title_done = false
+		vim.notify("Tau session title not saved: " .. tostring(save_err), vim.log.levels.ERROR)
+		return
+	end
+	local ui = require("tau.ui")
+	if ui.active then
+		ui.active.session = session
+	end
+	vim.schedule(function()
+		require("tau.ui").refresh_winbar()
+	end)
+	vim.notify("Session title: " .. title, vim.log.levels.INFO)
+end
+
+function M.maybe_apply(session)
+	if not session then
+		return
+	end
+	local cfg = require("tau.config").get()
+	local scfg = cfg.session or {}
+	if not scfg.auto_llm_title then
+		return
+	end
+	if session.name and session.name ~= "" then
+		return
+	end
+	if session._tau_llm_title_done then
+		return
+	end
+	if not has_assistant_reply(session.messages) then
+		return
+	end
+
+	local sid = session.id
+	vim.defer_fn(function()
+		M._run(sid)
+	end, 100)
+end
+
+function M.generate_now(opts)
+	opts = opts or {}
+	local state = require("tau.state")
+	local session = state.get_session()
+	if not session then
+		vim.notify("No active session", vim.log.levels.WARN)
+		return
+	end
+	if not has_assistant_reply(session.messages) then
+		vim.notify("Need at least one assistant message to title the session", vim.log.levels.WARN)
+		return
+	end
+	if opts.force then
+		session.name = nil
+	end
+	session._tau_llm_title_done = false
+	session._tau_llm_title_attempts = 0
+	M._run(session.id)
+end
+
+return M

--- a/lua/tau/state.lua
+++ b/lua/tau/state.lua
@@ -26,8 +26,10 @@ end
 
 function M.create_session(opts)
 	opts = opts or {}
+	local h = vim.loop.hrtime() or 0
+	local suffix = string.format("%012x", h % 0xFFFFFFFFFFFF)
 	return {
-		id = opts.id or vim.fn.strftime("%Y%m%d-%H%M%S") .. "-" .. vim.fn.rand(),
+		id = opts.id or (vim.fn.strftime("%Y%m%d-%H%M%S") .. "-" .. suffix),
 		cwd = opts.cwd or vim.fn.getcwd(),
 		name = opts.name or nil,
 		parent_id = opts.parent_id,

--- a/lua/tau/state.lua
+++ b/lua/tau/state.lua
@@ -30,6 +30,7 @@ function M.create_session(opts)
 		id = opts.id or vim.fn.strftime("%Y%m%d-%H%M%S") .. "-" .. vim.fn.rand(),
 		cwd = opts.cwd or vim.fn.getcwd(),
 		name = opts.name or nil,
+		parent_id = opts.parent_id,
 		messages = opts.messages or {},
 		model = opts.model or require("tau.config").get().provider.model,
 		provider = opts.provider or require("tau.config").get().provider.name,

--- a/lua/tau/ui.lua
+++ b/lua/tau/ui.lua
@@ -82,25 +82,7 @@ function M.open(opts)
 	vim.wo[layout_state.prompt].relativenumber = false
 
 	local function get_info_str()
-		local cfg = require("tau.config").get()
-		local provider_name = session and session.provider or cfg.provider.name or "default"
-		local model = session and session.model or cfg.provider.model
-		if not model then
-			model = require("tau.models").get_active()
-		end
-		if not model then
-			local plugin = require("tau.plugin").get_provider(provider_name)
-			if plugin then
-				model = plugin.default_model
-			end
-		end
-		if not model then
-			local fallback = require("tau.plugin").get_fallback_models(provider_name)
-			if fallback and #fallback > 0 then
-				model = fallback[1]
-			end
-		end
-		return string.format(" %s | %s ", provider_name, model or "default")
+		return require("tau.session_display").winbar_text(session)
 	end
 
 	if config.layout.side.panels.history.winbar then
@@ -221,6 +203,7 @@ function M.open(opts)
 		augroup = augroup,
 	}
 
+	M.refresh_winbar()
 	layout.focus_prompt(layout_state)
 
 	return M.active
@@ -263,28 +246,26 @@ function M.refresh_winbar()
 	if not M.active then
 		return
 	end
-	local session = M.active.session
-	local cfg = require("tau.config").get()
-	local provider_name = session and session.provider or cfg.provider.name or "default"
-	local model = session and session.model or cfg.provider.model
-	if not model then
-		model = require("tau.models").get_active()
-	end
-	if not model then
-		local plugin = require("tau.plugin").get_provider(provider_name)
-		if plugin then
-			model = plugin.default_model
-		end
-	end
-	if not model then
-		local fallback = require("tau.plugin").get_fallback_models(provider_name)
-		if fallback and #fallback > 0 then
-			model = fallback[1]
-		end
-	end
-	local info_str = string.format(" %s | %s ", provider_name, model or "default")
+	local session = require("tau.state").get_session()
+	M.active.session = session
+	local info_str = require("tau.session_display").winbar_text(session)
 	local layout_state = M.active.layout_state
 	local config = M.active.config
+	if layout_state.layout == "float" and layout_state.main and vim.api.nvim_win_is_valid(layout_state.main) then
+		local short = "τ"
+		if session and session.name and session.name ~= "" then
+			short = session.name
+		elseif session and session.id and session.id ~= "" then
+			short = session.id
+			if #short > 28 then
+				short = short:sub(1, 25) .. "…"
+			end
+		end
+		pcall(vim.api.nvim_win_set_config, layout_state.main, {
+			title = " " .. short .. " ",
+			title_pos = "center",
+		})
+	end
 	if config.layout.side.panels.history.winbar then
 		pcall(function()
 			vim.wo[layout_state.history].winbar = " History " .. info_str
@@ -567,6 +548,7 @@ function M.finish_turn()
 	local s = require("tau.state").get_session()
 	if s then
 		require("tau.session").TauSessionAutosave(s)
+		require("tau.session_title").maybe_apply(s)
 	end
 
 	if queue.size() > 0 then

--- a/lua/tau/ui.lua
+++ b/lua/tau/ui.lua
@@ -16,13 +16,34 @@ function M.open(opts)
 	local state = require("tau.state")
 
 	if M.active and layout.is_open(M.active.layout_state) then
+		if opts.resume then
+			local session = state.get_session()
+			M.active.session = session
+			history.refresh(M.active.hist_buf, session, M.active.config)
+			history.scroll_to_bottom(M.active.hist_buf, M.active.layout_state.history)
+			M.refresh_winbar()
+			layout.focus_prompt(M.active.layout_state)
+			return M.active
+		end
+		require("tau").new_session({ silent = true })
+		local session = state.get_session()
+		M.active.session = session
+		history.refresh(M.active.hist_buf, session, M.active.config)
+		history.scroll_to_bottom(M.active.hist_buf, M.active.layout_state.history)
+		M.refresh_winbar()
 		layout.focus_prompt(M.active.layout_state)
 		return M.active
 	end
 
-	local session = state.get_session()
-	if not session then
-		require("tau").new_session()
+	local session
+	if opts.resume then
+		session = state.get_session()
+		if not session then
+			require("tau").new_session({ silent = true })
+			session = state.get_session()
+		end
+	else
+		require("tau").new_session({ silent = true })
 		session = state.get_session()
 	end
 
@@ -323,6 +344,10 @@ function M.on_submit(text)
 			_queued = true,
 			_queue_type = "steer",
 		})
+		local steer_session = require("tau.state").get_session()
+		if steer_session then
+			require("tau.session").TauSessionAutosave(steer_session)
+		end
 		M.refresh()
 		return
 	end
@@ -341,6 +366,7 @@ function M.on_submit(text)
 
 	local hist = require("tau.history")
 	table.insert(session.messages, hist.user(expanded))
+	require("tau.session").TauSessionAutosave(session)
 
 	M.refresh()
 	M.start_turn()
@@ -538,6 +564,10 @@ function M.finish_turn()
 	M.stop_busy()
 	M.refresh()
 	require("tau.state").update_session_tokens()
+	local s = require("tau.state").get_session()
+	if s then
+		require("tau.session").TauSessionAutosave(s)
+	end
 
 	if queue.size() > 0 then
 		local next_msg = queue.pop()

--- a/lua/tau/ui/zen.lua
+++ b/lua/tau/ui/zen.lua
@@ -217,51 +217,13 @@ function M.exit()
   local config = ui.active.config
   if config.layout.side.panels.history.winbar then
     pcall(function()
-      local session = ui.active.session
-      local cfg = require("tau.config").get()
-      local provider_name = session and session.provider or cfg.provider.name or "default"
-      local model = session and session.model or cfg.provider.model
-      if not model then
-        model = require("tau.models").get_active()
-      end
-      if not model then
-        local plugin = require("tau.plugin").get_provider(provider_name)
-        if plugin then
-          model = plugin.default_model
-        end
-      end
-      if not model then
-        local fallback = require("tau.plugin").get_fallback_models(provider_name)
-        if fallback and #fallback > 0 then
-          model = fallback[1]
-        end
-      end
-      local info_str = string.format(" %s | %s ", provider_name, model or "default")
+      local info_str = require("tau.session_display").winbar_text(ui.active.session)
       vim.wo[ls.history].winbar = " History " .. info_str
     end)
   end
   if config.layout.side.panels.prompt.winbar then
     pcall(function()
-      local session = ui.active.session
-      local cfg = require("tau.config").get()
-      local provider_name = session and session.provider or cfg.provider.name or "default"
-      local model = session and session.model or cfg.provider.model
-      if not model then
-        model = require("tau.models").get_active()
-      end
-      if not model then
-        local plugin = require("tau.plugin").get_provider(provider_name)
-        if plugin then
-          model = plugin.default_model
-        end
-      end
-      if not model then
-        local fallback = require("tau.plugin").get_fallback_models(provider_name)
-        if fallback and #fallback > 0 then
-          model = fallback[1]
-        end
-      end
-      local info_str = string.format(" %s | %s ", provider_name, model or "default")
+      local info_str = require("tau.session_display").winbar_text(ui.active.session)
       vim.wo[new_prompt].winbar = " Prompt " .. info_str
     end)
   end

--- a/plugin/tau.lua
+++ b/plugin/tau.lua
@@ -42,6 +42,27 @@ cmd("TauNew", function()
 	require("tau").new_session()
 end, { nargs = 0, desc = "Start a new tau session" })
 
+cmd("TauNewSession", function()
+	require("tau").new_session()
+end, { nargs = 0, desc = "Start a new tau session" })
+
+cmd("TauSessionName", function(opts)
+	require("tau").set_session_name(opts.args)
+end, { nargs = "*", desc = "Set display name for the current session" })
+
+cmd("TauSessionEnd", function()
+	require("tau").end_session()
+end, { nargs = 0, desc = "Stop streaming, close UI, clear tab session" })
+
+cmd("TauExport", function(opts)
+	local path = table.concat(opts.fargs or {}, " ")
+	require("tau").export_session_html(path)
+end, { nargs = "+", complete = "file", desc = "Export current session to HTML" })
+
+cmd("TauSessionInfo", function()
+	require("tau").session_info()
+end, { nargs = 0, desc = "Show session id, path, tokens, cost" })
+
 cmd("TauContinue", function()
 	require("tau").continue_session()
 end, { nargs = 0, desc = "Continue the most recent session" })

--- a/plugin/tau.lua
+++ b/plugin/tau.lua
@@ -63,6 +63,14 @@ cmd("TauSessionInfo", function()
 	require("tau").session_info()
 end, { nargs = 0, desc = "Show session id, path, tokens, cost" })
 
+cmd("TauSessionTitleLlm", function(opts)
+	require("tau").generate_session_title({ force = opts.bang or false })
+end, {
+	bang = true,
+	nargs = 0,
+	desc = "Set session name via LLM (! replace existing name)",
+})
+
 cmd("TauContinue", function()
 	require("tau").continue_session()
 end, { nargs = 0, desc = "Continue the most recent session" })


### PR DESCRIPTION
Adds **persistent JSONL sessions** under `stdpath("state")/tau/sessions/`, a **pluggable storage API** for other plugins, **Neovim commands** for session lifecycle, and **LLM-generated session titles**. The chat **winbar** shows **session title (or short id) · provider | model**, and session list uses the same **`vim.ui.select`** flow as model/thinking pickers.

### Session storage

- **Path:** `~/.local/state/nvim/tau/sessions/<cwd-hash>/<session-id>.jsonl` (first line = session meta, following lines = messages).
- **API:** `TauRegisterSessionStorage`, `TauSetSessionStorage`, `TauGetSessionStorage` (provider must implement `list_sessions`, `load_session`, `save_session`, `delete_session`). Built-in **`jsonl`** backend registered by default.
- **Public:** `require("tau").TauRegisterSessionStorage` / `TauSetSessionStorage` / `TauGetSessionStorage` (and snake_case aliases).

### Commands & behavior

- **`:Tau`** — opens chat and always starts a **new** session (silent when reopening an existing layout).
- **`:TauContinue`** / **`:TauResume`** — load most recent or pick a session (CWD-scoped); **`:TauResume`** uses **`vim.ui.select`**; list sorted by **last edited**; labels show **name, edited time, message count**.
- **`:TauNewSession`** / **`:TauSessionName`**, **`:TauSessionEnd`**, **`:TauExport`**, **`:TauSessionInfo`**, **`:TauSessionTitleLlm`** (`!` forces regenerate).
- **`TauStop`** — unchanged (stop streaming); full teardown remains **`:TauSessionEnd`**.
- **`lua/tau/rpc.lua`** — thin wrapper over **`tau.dispatcher`** for **`stop`/`abort`** (fixes missing module).

### Session branching (Lua API)

- **`require("tau").TauSessionTree()`** — pick a message, fork from there.
- **`TauSessionFork(message_index)`**, **`TauSessionClone()`**
- Slash **`/tree`**, **`/fork`**, **`/clone`** removed in favor of these APIs.

### UI / UX

- **`session_display.winbar_text`** — shared winbar string; **zen** layout uses the same helper.
- **`refresh_winbar`** always syncs **`M.active.session`** from **`state.get_session()`** so titles and ids are not stale.
- **`new_session()`** refreshes the UI when Tau is open.
- **Float** layout outer **title** updates with session name / short id.
- Resuming a session when Tau was closed uses **`ui.open({ resume = true })`** so the loaded session is not replaced by a blank one.

### LLM session titles

- **Config** (defaults in **`tau.config`**, overridable in **`setup()`**): `session.auto_llm_title`, `title_max_chars_excerpt`, `title_max_length`, `title_model`.
- After a completed turn, **`session_title.maybe_apply`** may call the API with a small prompt; title is sanitized and saved.
- Eligibility includes assistant turns with **text**, **tool_calls**, or **reasoning_content**; excerpt includes reasoning when useful.
- **`api.call` / `api.stream`** accept **`opts.model`** for optional overrides (e.g. cheap title model).

### Persistence hardening

- Session header **`name`** is only written as a **non-empty string**; **`writefile(..., "s")`** when possible, with fallback without **`s`**.
- After writing a session **with** a name, **read-back check** ensures **`name`** in the file matches; otherwise save fails with a clear error.
- **Load** normalizes **`name`** to a string or **`nil`**.
- Session **ids** use **timestamp + `hrtime` hex suffix** (no **`vim.fn.rand()`**).
- Title flow uses **`result.text`** or **`result.thinking`**; **`TauSessionAutosave`** returns **`ok, err`**; failed title save surfaces an **ERROR** and allows retry.

### Misc

- Neovim user config can set `session = { auto_llm_title = true }` in **`tau.setup`** (defaults already enable LLM titles).